### PR TITLE
fixed issue where parks with apostrophe's in name would cause error

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -36,8 +36,9 @@ function renderFavorites(favoriteParks) {
     console.log('There are ' + favoriteParks.length + ' favorite parks.')
     for (let i = 0; i < favoriteParks.length; i++) {
       favItemName = favoriteParks[i].parkName;
+      favItemNameA = favoriteParks[i].parkFullName
       favParkCode = favoriteParks[i].parkCode;
-      favListLi = `<li id='park-${favParkNum}'><a href='#' onclick='openFavPark("${favParkCode}","${favItemName}")'> ${favItemName} </a></li>`;
+      favListLi = `<li id='park-${favParkNum}'><a href='#' onclick='openFavPark("${favParkCode}","${favItemName}")'> ${favItemNameA} </a></li>`;
       favList += favListLi;
       favParkNum++
 
@@ -229,7 +230,10 @@ function closeModal() {
 
 function addFavoritePark() {
   document.getElementById("favButton").innerHTML = "Added!"
-  let newEntry = { parkName: parkData.data[parkSelected].fullName, parkCode: parkData.data[parkSelected].parkCode }
+  let parkNameContainer = parkData.data[parkSelected].fullName;
+  let newParkName = parkNameContainer.replace("'", "")
+
+  let newEntry = { parkName: newParkName, parkCode: parkData.data[parkSelected].parkCode, parkFullName: parkData.data[parkSelected].fullName}
   favoriteParks.push(newEntry);
   localStorage.setItem("favoriteParksCollection", JSON.stringify(favoriteParks));
   console.log(favoriteParks);

--- a/index.html
+++ b/index.html
@@ -80,87 +80,15 @@
                 </div>
             </div>
         </div>
-    </div>
-
- <!-- Modal Start-->
-<div class="parkModal fixed z-10 inset-0 overflow-y-auto" id="parkModal" pstyle="visibility: visible; display: none;"
-    aria-labelledby="modal-title" role="dialog" aria-modal="true">
- <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-
-     <div class="fixed inset-0 bg-green-900 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
-
-     <!-- This element is to trick the browser into centering the modal contents. -->
-     <span class="hidden sm:inline-block sm:align-middle sm:h-1/2" aria-hidden="true">&#8203;</span>
-
-     <div
-         class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-screen-xl sm:w-full w-full">
-         <div class="bg-yellow-100 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-            <!-- Modal Image Banner -->
-             <div class="modalBannerImage"></div> 
-             <h3 class="text-2xl leading-6 font-medium text-gray-900 italic mt-4" id="parkName">null</h3>
-             <div class="flex flex-wrap -mx-4 overflow-hidden">
-                <!-- Park Column -->
-                 <div class="my-4 px-4 w-1/2 overflow-hidden">
-                     <h3 class="text-lg leading-10 font-medium text-gray-800" id="parkName"><i
-                             class="fa fa-tree text-gray-700" aria-hidden="true"></i> Details</h3>
-                     <span class="font-semibold">Description:</span> <span class="font-light"
-                         id="parkDescription">null</span><br>
-                     <span class="font-semibold">Designation:</span> <span class="font-light"
-                         id="parkDesignation">null</span><br>
-                     <span class="font-semibold">Address:</span> <span class="font-light"
-                         id="parkAddress"></span><br>
-                     <span class="font-semibold">Entry Fee:</span> <span class="font-light"
-                         id="parkFeeCost">null</span><br>
-                     <span class="font-semibold">Entry Info:</span> <span class="font-light" id="parkFeeDescription">null</span>
-                 </div>
-                 <!-- Weather Column -->
-                 <div class="my-4 px-4 w-1/2 overflow-hidden">
-                     <h3 class="text-lg leading-10 font-medium text-gray-800" id="parkName"><i
-                             class="fa fa-sun text-gray-700" aria-hidden="true"></i> Weather</h3>
-                             <span class="font-semibold">Current Temp:</span> <span class="font-light" id="weatherTempCurrent">null</span><br>
-                             <span class="font-semibold">Feels Like:</span> <span class="font-light" id="weatherFeelsLikeTemp">null</span><br>
-                             <span class="font-semibold">Humidity:</span> <span class="font-light" id="weatherHumidity">null</span><br>
-                             <span class="font-semibold">Weather Conditions:</span> <span class="font-light" id="weatherConditions">null</span><br>
-                             <span class="font-semibold">Wind Speed:</span> <span class="font-light" id="weatherWindSpeed">null</span><br>
-                 </div>
-             </div>
-
-         </div>
-         <div class="bg-yellow-200 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-             <button type="button" onclick="addFavoritePark()" id="favButton"
-                 class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-green-800 text-base font-medium text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm">
-                 <i class="fa fa-star py-1 px-1" aria-hidden="true"></i> Add to Favorites
-             </button>
-             <button type="button" onclick="openParkWebsite()"
-                 class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-grey-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-                 Official Website
-             </button>
-
-             <button type="button" onclick="openMap()"
-                 class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-grey-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-                 Map
-             </button>
-
-             <button type="button" onclick="closeModal()"
-                 class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-grey-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-                 Close
-             </button>
-
-             <!--<button type="button" onclick="test()"
-                 class="mt-3 w-full inline-flex justify-center rounded-md border border-red-300 shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-grey-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-                 Test
-             </button>-->
+        </div>
 
         <!-- Modal Start-->
         <div class="parkModal fixed z-10 inset-0 overflow-y-auto" id="parkModal"
             style="visibility: visible; display: none;" aria-labelledby="modal-title" role="dialog" aria-modal="true">
             <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-
                 <div class="fixed inset-0 bg-green-900 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
-
                 <!-- This element is to trick the browser into centering the modal contents. -->
                 <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
-
                 <div
                     class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-screen-xl sm:w-full">
                     <div class="bg-yellow-100 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
@@ -199,7 +127,6 @@
                                     id="weatherWindSpeed">null</span><br>
                             </div>
                         </div>
-
                     </div>
                     <div class="bg-yellow-200 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
                         <button type="button" onclick="addFavoritePark()" id="favButton"
@@ -210,22 +137,18 @@
                             class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-grey-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
                             Official Website
                         </button>
-
                         <button type="button" onclick="openMap()"
                             class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-grey-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
                             Map
                         </button>
-
                         <button type="button" onclick="closeModal()"
                             class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-grey-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
                             Close
                         </button>
-
                         <!--<button type="button" onclick="test()"
                  class="mt-3 w-full inline-flex justify-center rounded-md border border-red-300 shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-grey-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
                  Test
              </button>-->
-
                     </div>
                 </div>
             </div>
@@ -270,7 +193,7 @@
                                 class="mt-3 w-full inline-flex justify-center rounded-md border border-red-300 shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-grey-500 sm:mt-0 sm:ml-3 sm:w-full sm:text-sm">
                                 <i class="fa fa-trash py-1 px-1"></i> Clear Favorites
                             </button>
-                            
+
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
- fixed issue where parks with apostrophe's in name would cause error and not open the park modal
- added main's html to fix the nested div issue for the modal(see prior hotfix in main)
- added extra child to fav parks local storage to render the name correctly in the anchor element so that it matches the anchor element from the rendered list of parks.
